### PR TITLE
travis,setup.py: Drop end-of-lifed python3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 # Existing Python versions
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
 # Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setuptools.setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 2.7",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",


### PR DESCRIPTION
Python 3.4 was EOLed in March 2019