### PR TITLE
Travis CI infra updates (common distro, pre-release Python 3.8 testing)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8-dev"
+matrix:
+  allow_failures:
+  - python: "3.8-dev"
 before_install: pip install pipenv
 install: pipenv install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,13 @@
 language: python
+# Python 3.7+ require Ubuntu Xenial (16.04 LTS) or greater
+# https://docs.travis-ci.com/user/languages/python/#development-releases-support
+dist: xenial
 # Existing Python versions
 python:
   - "2.7"
   - "3.5"
   - "3.6"
-# Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
-matrix:
-  include:
-    - python: "3.7"
-      dist: xenial
-      sudo: required
+  - "3.7"
 before_install: pip install pipenv
 install: pipenv install
 script:


### PR DESCRIPTION
A couple of related updates, to reflect current default environments provided by Travis CI:
- Testing against a more modern, supported Ubuntu Xenial (16.04 LTS).
- Removal of a corner-case for Python 3.7+, making testing more consistent.
- Support optional testing of pre-release Python 3.8