### PR TITLE
Replace pendulum with the built-in time module. This fixes #7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,11 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
-  - "3.8-dev"
+  - "3.8"
+  - "nightly"
 matrix:
   allow_failures:
-  - python: "3.8-dev"
+  - python: "nightly"
 before_install: pip install pipenv
 install: pipenv install
 script:

--- a/Pipfile
+++ b/Pipfile
@@ -8,4 +8,3 @@ name = "pypi"
 [packages]
 requests = "*"
 six = "*"
-pendulum = "*"

--- a/reposit/data/api.py
+++ b/reposit/data/api.py
@@ -4,7 +4,7 @@ Define an API connection object
 import logging
 
 import requests
-import pendulum
+import time
 
 from reposit.data.exceptions import InvalidControllerException
 from reposit.data.utils import is_valid_url, deepest_key, match_to_schema
@@ -94,7 +94,7 @@ class ApiRequest(object):
         :return:
         """
         if not end:
-            end = pendulum.now().int_timestamp
+            end = int(time.time())
 
         resp = requests.get(
             '{}?start={}&end={}'.format(self.url, start, end),

--- a/reposit/data/api.py
+++ b/reposit/data/api.py
@@ -2,9 +2,9 @@
 Define an API connection object
 """
 import logging
+import time
 
 import requests
-import time
 
 from reposit.data.exceptions import InvalidControllerException
 from reposit.data.utils import is_valid_url, deepest_key, match_to_schema

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,9 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="reposit",
-    version="0.4.0",
+    version="0.5.0",
     author="Thomas Basche",
-    author_email="thomas.basche@repositpower.com",
+    author_email="tcbasche@gmail.com",
     description="A library to communicate with a Reposit Controller",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -15,11 +15,11 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         'requests',
-        'pendulum',
         'six'
     ],
     classifiers=(
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 2.7",


### PR DESCRIPTION
Fixes #7 where pendulum doesn't work on Windows. 

It was only used in one place so just use time.time() instead.